### PR TITLE
ci: Locate file:line in golangci-lint

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -26,6 +26,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: latest
+        args: "--out-${NO_FUTURE}format colored-line-number"
 
   test:
     name: Build and test - Go ${{ matrix.go_version }}


### PR DESCRIPTION
Signed-off-by: Jiangnan Jia <jnan0806@gmail.com>

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Now, the golangci-lint can not locate the file:line when lint occurs error,like following:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/43714056/209032711-d641de01-e2f8-471d-abbf-bd6289fd4db7.png">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #18 

**Describe how you did it**:
add args according https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648
